### PR TITLE
Retrieve audio at maximum bitrate

### DIFF
--- a/main.py
+++ b/main.py
@@ -167,7 +167,7 @@ async def on_callback(callback: types.CallbackQuery):
         thumb = f"cache/thumb_{yt.video_id}.jpg"
 
         log.info(f"Downloading {yt.watch_url} into {filename}...")
-        yt.streams.filter(only_audio=True).first().download(filename=filename)
+        yt.streams.get_audio_only().download(filename=filename)
         save_url(yt.thumbnail_url, thumb)
         log.success("Succesfully donwloaded")
         log.info("Uploading...")


### PR DESCRIPTION
Use `StreamQuery.get_audio_only()` instead of `StreamQuery.filter(only_audio=True).first()` for retrieving audio
[`StreamQuery.get_audio_only()`](https://pytube.io/en/latest/api.html?highlight=get_audio_only#pytube.query.StreamQuery.get_audio_only) in docs:
> Get highest bitrate audio stream for given codec